### PR TITLE
Filenames not capitalized

### DIFF
--- a/plugins/eliza/eliza.rb
+++ b/plugins/eliza/eliza.rb
@@ -1,5 +1,5 @@
-require 'tweaksiri'
-require 'siriobjectgenerator'
+require 'tweakSiri'
+require 'siriObjectGenerator'
 require 'net/http'
 
 

--- a/plugins/testproxy/testproxy.rb
+++ b/plugins/testproxy/testproxy.rb
@@ -1,4 +1,4 @@
-require 'tweaksiri'
+require 'tweakSiri'
 require 'siriObjectGenerator'
 
 #######

--- a/plugins/testproxy/testproxy.rb
+++ b/plugins/testproxy/testproxy.rb
@@ -1,5 +1,5 @@
 require 'tweaksiri'
-require 'siriobjectgenerator'
+require 'siriObjectGenerator'
 
 #######
 # This is a "hello world" style plugin. It simply intercepts the phrase "text siri proxy" and responds

--- a/plugins/thermostat/siriThermostat.rb
+++ b/plugins/thermostat/siriThermostat.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
-require 'tweaksiri'
-require 'siriobjectgenerator'
+require 'tweakSiri'
+require 'siriObjectGenerator'
 require 'json' 
 require 'open-uri'
 require 'httparty'

--- a/siriProxy.rb
+++ b/siriProxy.rb
@@ -4,7 +4,7 @@ require 'eventmachine'
 require 'zlib'
 require 'cfpropertylist'
 require 'pp'
-require 'tweaksiri'
+require 'tweakSiri'
 require 'interpretSiri'
 
 LOG_LEVEL = 1

--- a/siriProxy.rb
+++ b/siriProxy.rb
@@ -244,7 +244,7 @@ end
 class SiriProxy
 	def initialize(pluginClasses=[])
 		EventMachine.run do
-			EventMachine::start_server('0.0.0.0', 443, SiriIPhoneConnection) { |conn|
+			EventMachine::start_server('0.0.0.0', 4443, SiriIPhoneConnection) { |conn|
 				conn.pluginManager = SiriPluginManager.new(
 					pluginClasses
 				)

--- a/start.rb
+++ b/start.rb
@@ -2,8 +2,8 @@
 require 'plugins/thermostat/siriThermostat'
 require 'plugins/testproxy/testproxy'
 require 'plugins/eliza/eliza'
-require 'tweaksiri'
-require 'siriproxy'
+require 'tweakSiri'
+require 'siriProxy'
 
 #Also try Eliza -- though it should really not be run "before" anything else.
 PLUGINS = [TestProxy]

--- a/start.rb
+++ b/start.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require 'plugins/thermostat/sirithermostat'
+require 'plugins/thermostat/siriThermostat'
 require 'plugins/testproxy/testproxy'
 require 'plugins/eliza/eliza'
 require 'tweaksiri'

--- a/start.rb
+++ b/start.rb
@@ -6,7 +6,7 @@ require 'tweakSiri'
 require 'siriProxy'
 
 #Also try Eliza -- though it should really not be run "before" anything else.
-PLUGINS = [TestProxy]
+PLUGINS = [Eliza]
 
 proxy = SiriProxy.new(PLUGINS)
 


### PR DESCRIPTION
Filenames weren't capitalized in the requires at the top of a bunch of files. I've fixed all the ones that were preventing the proxy from starting.
