### PR TITLE
require error - cfpropertylist

### DIFF
--- a/siriProxy.rb
+++ b/siriProxy.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'eventmachine'
 require 'zlib'
-require 'CFPropertyList'
+require 'cfpropertylist'
 require 'pp'
 require 'tweakSiri'
 require 'interpretSiri'


### PR DESCRIPTION
this pull request fixes the require cfpropertylist error in siriProxy.rb
