### PR TITLE
Fix 0 byte ca.pem from gen_certs.sh

### DIFF
--- a/scripts/gen_certs.sh
+++ b/scripts/gen_certs.sh
@@ -24,6 +24,7 @@ echo "" > $LOG_FILE
 echo "Creating CA directory"
 mkdir -p $TMP_CA_DIR/{certs,crl,newcerts,private}
 touch $TMP_CA_DIR/index.txt
+touch $TMP_CA_DIR/index.txt.attr
 echo 01 > $TMP_CA_DIR/crtnumber
 
 echo "Generating '${commonName}' CA request"

--- a/scripts/openssl.cnf
+++ b/scripts/openssl.cnf
@@ -72,7 +72,7 @@ cert_opt 	= ca_default		# Certificate field options
 
 default_days	= 365			# how long to certify for
 default_crl_days= 30			# how long before next CRL
-default_md	= default		# use public key default MD
+default_md	= md5		# use public key default MD
 preserve	= no			# keep passed DN ordering
 
 # A few difference way of specifying how similar the request should look


### PR DESCRIPTION
On Lion 10.7.2 openssl was complaining about using a 'default' digest and missing file.

I picked md5 as the default as we are not doing anything crazy secure (given we are a tamper proxy anyway); however we could have just as easily picked sha1 here too.
