### PR TITLE
Add the magic comment to force encoding to UTF-8 to all ruby files.

### DIFF
--- a/lib/siri_objects.rb
+++ b/lib/siri_objects.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'rubygems'
 require 'uuidtools'
 

--- a/lib/siriproxy.rb
+++ b/lib/siriproxy.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'eventmachine'
 require 'zlib'
 require 'pp'

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'optparse'
 require 'yaml'
 require 'ostruct'

--- a/lib/siriproxy/connection.rb
+++ b/lib/siriproxy/connection.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'cfpropertylist'
 require 'siriproxy/interpret_siri'
 

--- a/lib/siriproxy/connection/guzzoni.rb
+++ b/lib/siriproxy/connection/guzzoni.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 #####
 # This is the connection to the Guzzoni (the Siri server backend)
 #####

--- a/lib/siriproxy/connection/iphone.rb
+++ b/lib/siriproxy/connection/iphone.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 #####
   # This is the connection to the iPhone
 #####

--- a/lib/siriproxy/interpret_siri.rb
+++ b/lib/siriproxy/interpret_siri.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 ######
 # The idea behind this class is that you can call the different
 # methods to get different interpretations of a Siri object.

--- a/lib/siriproxy/plugin.rb
+++ b/lib/siriproxy/plugin.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'cora'
 
 class SiriProxy::Plugin < Cora::Plugin

--- a/lib/siriproxy/plugin_manager.rb
+++ b/lib/siriproxy/plugin_manager.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'cora'
 require 'pp'
 

--- a/lib/siriproxy/version.rb
+++ b/lib/siriproxy/version.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 class SiriProxy
   VERSION = "0.2.2"
 end

--- a/plugins/siriproxy-example/lib/siriproxy-example.rb
+++ b/plugins/siriproxy-example/lib/siriproxy-example.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'cora'
 require 'siri_objects'
 


### PR DESCRIPTION
I'm not sure 100% it will fix issue #50 but it's worth the try

original pull request #94
