### PR TITLE
SiriProxy: Expand the path to the lib folder before adding it to $LOAD_PATH

### DIFF
--- a/bin/siriproxy
+++ b/bin/siriproxy
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-$LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$: << File.expand_path('../../lib', __FILE__)
 
 require 'siriproxy/command_line'
 


### PR DESCRIPTION
The path should be expanded on Ruby 1.9

Original pull request #95

closes #65
