### PR TITLE
Modifies siriproxy gencerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Clone this repo locally, then navigate into the SiriProxy directory (the root of
 	`cp ./config.example.yml ~/.siriproxy/config.yml`  
 5. Generate certificates:  
 	`siriproxy gencerts *(optional) ip address/domain you are listening on*` 
-	for example: `siriproxy gencerts 172.0.0.1` OR `siriproxy gencerts`
+	for example: `siriproxy gencerts 172.0.0.1` OR `siriproxy gencerts` 
+	if you are not using spire, use the latter option
 6. Install `~/.siriproxy/ca.pem` on your phone. This can easily be done by emailing the file to yourself and clicking on it in the iPhone email app. Follow the prompts.
 7. Bundle SiriProxy (this should be done every time you change the config.yml):  
 	`siriproxy bundle`

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Clone this repo locally, then navigate into the SiriProxy directory (the root of
 4. Move default config file to .siriproxy (if you need to make configuration changes, do that now by editing the config.yml):  
 	`cp ./config.example.yml ~/.siriproxy/config.yml`  
 5. Generate certificates:  
-	`siriproxy gencerts *ip address/domain you are listening on*` eg `siriproxy gencerts 172.0.0.1`
+	`siriproxy gencerts *(optional) ip address/domain you are listening on*` 
+	for example: `siriproxy gencerts 172.0.0.1` OR `siriproxy gencerts`
 6. Install `~/.siriproxy/ca.pem` on your phone. This can easily be done by emailing the file to yourself and clicking on it in the iPhone email app. Follow the prompts.
 7. Bundle SiriProxy (this should be done every time you change the config.yml):  
 	`siriproxy bundle`

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Clone this repo locally, then navigate into the SiriProxy directory (the root of
 4. Move default config file to .siriproxy (if you need to make configuration changes, do that now by editing the config.yml):  
 	`cp ./config.example.yml ~/.siriproxy/config.yml`  
 5. Generate certificates:  
-	`siriproxy gencerts`
+	`siriproxy gencerts *ip address/domain you are listening on*` eg `siriproxy gencerts 172.0.0.1`
 6. Install `~/.siriproxy/ca.pem` on your phone. This can easily be done by emailing the file to yourself and clicking on it in the iPhone email app. Follow the prompts.
 7. Bundle SiriProxy (this should be done every time you change the config.yml):  
 	`siriproxy bundle`

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -97,7 +97,7 @@ Options:
     proxy.start()
   end
 
-  def gen_certs(subcommand)
+  def gen_certs(subcommand='guzzoni.apple.com')
     ca_name = @ca_name ||= ""
     command = File.join(File.dirname(__FILE__), '..', "..", "scripts", 'gen_certs.sh')
     sp_root = File.join(File.dirname(__FILE__), '..', "..")

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -97,7 +97,7 @@ Options:
     proxy.start()
   end
 
-  def gen_certs
+  def gen_certs(subcommand)
     ca_name = @ca_name ||= ""
     command = File.join(File.dirname(__FILE__), '..', "..", "scripts", 'gen_certs.sh')
     sp_root = File.join(File.dirname(__FILE__), '..', "..")

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -97,7 +97,7 @@ Options:
     proxy.start()
   end
 
-  def gen_certs(subcommand='guzzoni.apple.com')
+  def gen_certs(subcommand='')
     ca_name = @ca_name ||= ""
     command = File.join(File.dirname(__FILE__), '..', "..", "scripts", 'gen_certs.sh')
     sp_root = File.join(File.dirname(__FILE__), '..', "..")

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -35,7 +35,7 @@ Options:
     subcommand  = ARGV.shift
     case command
     when 'server'           then run_server(subcommand)
-    when 'gencerts'         then gen_certs
+    when 'gencerts'         then gen_certs(subcommand)
     when 'bundle'           then run_bundle(subcommand)
     when 'console'          then run_console
     when 'update'           then update(subcommand)
@@ -101,7 +101,7 @@ Options:
     ca_name = @ca_name ||= ""
     command = File.join(File.dirname(__FILE__), '..', "..", "scripts", 'gen_certs.sh')
     sp_root = File.join(File.dirname(__FILE__), '..', "..")
-    puts `#{command} "#{sp_root}" "#{ca_name}"`
+    puts `#{command} "#{sp_root}" "#{ca_name}" "#{subcommand}"`
   end
 
   def update(directory=nil)

--- a/scripts/gen_certs.sh
+++ b/scripts/gen_certs.sh
@@ -8,6 +8,12 @@ then
   commonName="SiriProxyCA"
 fi
 
+if [ "${hostName}" == "" ]
+then
+  hostName="guzzoni.apple.com"
+fi
+
+
 # Feel free to change any of these defaults
 countryName="US"
 stateOrProvinceName="Missouri"

--- a/scripts/gen_certs.sh
+++ b/scripts/gen_certs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+hostName=$3
 commonName=$2
 
 if [ "${commonName}" == "" ]
@@ -54,7 +55,7 @@ echo "${stateOrProvinceName}" >> $TMP_DIR/ca.args
 echo "${localityName}" >> $TMP_DIR/ca.args
 echo "${organizationName}" >> $TMP_DIR/ca.args
 echo "${organizationalUnitName}" >> $TMP_DIR/ca.args
-echo "guzzoni.apple.com" >> $TMP_DIR/ca.args
+echo "${hostName}" >> $TMP_DIR/ca.args
 echo "${emailAddress}" >> $TMP_DIR/ca.args
 echo "" >> $TMP_DIR/ca.args
 echo "" >> $TMP_DIR/ca.args


### PR DESCRIPTION
Gencerts is not compatible with spire when own domain/ip address is used. This patch changes the behaviour of gencerts to accept a domain/ip address as an additional argument.

When no argument is supplied, default behaviour is preserved, and guzzoni.apple.com is used.

Usage:

siriproxy gencerts 172.0.0.1
siriproxy gencerts
