### PR TITLE
Fixed typo 'laoded' to 'loaded'.

### DIFF
--- a/lib/siriproxy/plugin_manager.rb
+++ b/lib/siriproxy/plugin_manager.rb
@@ -25,7 +25,7 @@ class SiriProxy::PluginManager < Cora
           @plugins << plugin
       end
     end
-    log "Plugins laoded: #{@plugins}"
+    log "Plugins loaded: #{@plugins}"
   end
 
   def process_filters(object, direction)


### PR DESCRIPTION
There was a typo that would display laoded instead of loaded when loading plugins in the command line.
