### PR TITLE
Automatic updater, bundler or restarter

### DIFF
--- a/siriproxy-bundler
+++ b/siriproxy-bundler
@@ -1,0 +1,14 @@
+#!/bin/bash
+while true;
+do
+echo "Bundling and Starting Server"
+    if siriproxy update; then
+       echo "[Info - SiriProxy] Bundling Complete!"
+       siriproxy server;
+       echo "[Info - SiriProxy] Restarter Bye"
+      exit 1
+    else
+      echo "[Warning - Crash - SiriProxy] Crashed! Bundling then restarting in 2 sec!"
+      sleep 1
+    fi
+done

--- a/siriproxy-bundler
+++ b/siriproxy-bundler
@@ -2,9 +2,9 @@
 while true;
 do
 echo "[Info - SiriProxy] Bundling and Starting Server"
-    if siriproxy bundle; then
+    siriproxy bundle;
        echo "[Info - SiriProxy] Bundling Complete!"
-       siriproxy server;
+    if siriproxy server; then
        echo "[Info - SiriProxy] Restarter Bye"
       exit 1
     else

--- a/siriproxy-bundler
+++ b/siriproxy-bundler
@@ -1,8 +1,8 @@
 #!/bin/bash
 while true;
 do
-echo "Bundling and Starting Server"
-    if siriproxy update; then
+echo "[Info - SiriProxy] Bundling and Starting Server"
+    if siriproxy bundle; then
        echo "[Info - SiriProxy] Bundling Complete!"
        siriproxy server;
        echo "[Info - SiriProxy] Restarter Bye"

--- a/siriproxy-restarter
+++ b/siriproxy-restarter
@@ -1,0 +1,12 @@
+#!/bin/bash
+while true;
+do
+echo "Starting Server"
+    if siriproxy server; then
+       echo "[Info - SiriProxy] Restarter Bye"
+      exit 1
+    else
+      echo "[Warning - Crash - SiriProxy] Crashed! Updating then restarting in 2 sec!"
+      sleep 1
+    fi
+done

--- a/siriproxy-restarter
+++ b/siriproxy-restarter
@@ -1,7 +1,7 @@
 #!/bin/bash
 while true;
 do
-echo "Starting Server"
+echo "[Info - SiriProxy] Starting Server"
     if siriproxy server; then
        echo "[Info - SiriProxy] Restarter Bye"
       exit 1

--- a/siriproxy-updater
+++ b/siriproxy-updater
@@ -1,7 +1,7 @@
 #!/bin/bash
 while true;
 do
-echo "Updating and Starting Server"
+echo "[Info - SiriProxy] Updating and Starting Server"
     if siriproxy update; then
        echo "[Info - SiriProxy] Updating Complete!"
        siriproxy server;

--- a/siriproxy-updater
+++ b/siriproxy-updater
@@ -2,13 +2,13 @@
 while true;
 do
 echo "[Info - SiriProxy] Updating and Starting Server"
-    if siriproxy update; then
+    siriproxy update;
        echo "[Info - SiriProxy] Updating Complete!"
-       siriproxy server;
-       echo "[Info - SiriProxy] Restarter Bye"
+    if siriproxy server; then
+echo "[Info - SiriProxy] Restarter Bye"
       exit 1
     else
-      echo "[Warning - Crash - SiriProxy] Crashed! Updating then restarting in 2 sec!"
+echo "[Warning - Crash - SiriProxy] Crashed! Updating then restarting in 2 sec!"
       sleep 1
     fi
 done

--- a/siriproxy-updater
+++ b/siriproxy-updater
@@ -1,0 +1,14 @@
+#!/bin/bash
+while true;
+do
+echo "Updating and Starting Server"
+    if siriproxy update; then
+       echo "[Info - SiriProxy] Updating Complete!"
+       siriproxy server;
+       echo "[Info - SiriProxy] Restarter Bye"
+      exit 1
+    else
+      echo "[Warning - Crash - SiriProxy] Crashed! Updating then restarting in 2 sec!"
+      sleep 1
+    fi
+done


### PR DESCRIPTION
These files do exactly what they say. The restarter one will automatically restart when your proxy crashes. The updater will fully update, rake install, bundle, then restart your proxy. And the bundler will simply rebundle and restart your proxy.
To use you must first 'sudo chmod 777' each file.
Then to run use 'rvmsudo ./siriproxy-restarter' or whichever one it is you want..
I copied the siriproxy-restarter from Jimmy Kane's TLP SiriProxy and then just changed a couple things for the updater/bundler files
