### PR TITLE
Added --user option to `siriproxy server` which drops root privileges

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,24 +2,29 @@ source :gemcutter
 
 gemspec
 
-# load plugins
-require 'yaml'
-require 'ostruct'
-
-if !File.exists?(File.expand_path('~/.siriproxy/config.yml'))
-  $stderr.puts "config.yml not found. Copy config.example.yml to config.yml, then modify it."
-  exit 1
-end
-
 gem 'cora', :git => "git://github.com/chendo/cora.git"
 
-config = OpenStruct.new(YAML.load_file(File.expand_path('~/.siriproxy/config.yml')))
-if config.plugins
-  config.plugins.each do |plugin|
+if !File.exists?(File.expand_path('~/.siriproxy/config.yml'))
+  abort "config.yml not found. Copy config.example.yml to config.yml, then modify it."
+end
+
+require 'yaml'
+
+config_yml = File.expand_path('~/.siriproxy/config.yml')
+config = YAML.load_file(config_yml)
+
+if plugins = config['plugins']
+  plugins.each do |plugin|
     if plugin.is_a? String
       gem "siriproxy-#{plugin.downcase}"
     else
-      gem "siriproxy-#{plugin['gem'] || plugin['name'].downcase}", :path => plugin['path'], :git => plugin['git'], :branch => plugin['branch'], :require => plugin['require']
+      name = plugin['gem'] || plugin['name'].downcase
+
+      gem("siriproxy-#{name}",
+          :path => plugin['path'],
+          :git => plugin['git'],
+          :branch => plugin['branch'],
+          :require => plugin['require'])
     end
   end
 end

--- a/lib/siriproxy.rb
+++ b/lib/siriproxy.rb
@@ -28,6 +28,8 @@ class SiriProxy
           raise
         end
       end
+
+      EventMachine.set_effective_user($APP_CONFIG.user) if $APP_CONFIG.user
     end
   end
 end

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -149,6 +149,9 @@ Options:
       opts.on('-l', '--log LOG_LEVEL', '[server]   The level of debug information displayed (higher is more)') do |log_level|
         $APP_CONFIG.log_level = log_level
       end
+      opts.on('-u', '--user USER',     '[server]   The user to run as after launch') do |user|
+        $APP_CONFIG.user = user
+      end
       opts.on('-b', '--branch BRANCH', '[update]   Choose the branch to update from (default: master)') do |branch|
         @branch = branch
       end


### PR DESCRIPTION
Pull request for #334.

Running as root is undesirable as it allows plugins to perform unintentionally destructive or malicious actions at runtime.  This patch adds a --user option which allows the server to switch to an unprivileged user limiting the potential for harm from plugins.
