### PR TITLE
Allow the SiriProxy server host to use the redirecting DNS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The commands used in the video can be found at [https://gist.github.com/1428474]
 
 **Set up DNS**
 
-Before you can use SiriProxy, you must set up a DNS server on your network to forward requests for guzzoni.apple.com to the computer running the proxy (make sure that computer is not using your DNS server!). I recommend dnsmasq for this purpose. It's easy to get running and can easily handle this sort of behavior. ([http://www.youtube.com/watch?v=a9gO4L0U59s](http://www.youtube.com/watch?v=a9gO4L0U59s))
+Before you can use SiriProxy, you must set up a DNS server on your network to forward requests for guzzoni.apple.com to the computer running the proxy (siriproxy uses Google's public DNS servers to resolve guzzoni.apple.com, so it may use your forwarding DNS server). I recommend dnsmasq for this purpose. It's easy to get running and can easily handle this sort of behavior. ([http://www.youtube.com/watch?v=a9gO4L0U59s](http://www.youtube.com/watch?v=a9gO4L0U59s))
 
 **Set up RVM and Ruby 1.9.3**
 

--- a/lib/siriproxy.rb
+++ b/lib/siriproxy.rb
@@ -16,7 +16,7 @@ class SiriProxy
     EventMachine.run do
       begin
         puts "Starting SiriProxy on port #{$APP_CONFIG.port}.."
-        EventMachine::start_server('0.0.0.0', $APP_CONFIG.port, SiriProxy::Connection::Iphone) { |conn|
+        EventMachine::start_server('0.0.0.0', $APP_CONFIG.port, SiriProxy::Connection::Iphone, $APP_CONFIG.upstream_dns) { |conn|
           $stderr.puts "start conn #{conn.inspect}"
           conn.plugin_manager = SiriProxy::PluginManager.new()
           conn.plugin_manager.iphone_conn = conn

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -141,6 +141,10 @@ Options:
   
   def parse_options
     $APP_CONFIG = OpenStruct.new(YAML.load_file(File.expand_path('~/.siriproxy/config.yml')))
+
+    # Google Public DNS servers
+    $APP_CONFIG.upstream_dns ||= %w[8.8.8.8 8.8.4.4]
+
     @branch = nil
     @option_parser = OptionParser.new do |opts|
       opts.on('-p', '--port PORT',     '[server]   port number for server (central or node)') do |port_num|
@@ -148,6 +152,9 @@ Options:
       end
       opts.on('-l', '--log LOG_LEVEL', '[server]   The level of debug information displayed (higher is more)') do |log_level|
         $APP_CONFIG.log_level = log_level
+      end
+      opts.on(      '--upstream-dns SERVERS', Array, '[server]   List of upstream DNS servers to query for the real guzzoni.apple.com.  Defaults to Google DNS servers') do |servers|
+        $APP_CONFIG.upstream_dns = servers
       end
       opts.on('-b', '--branch BRANCH', '[update]   Choose the branch to update from (default: master)') do |branch|
         @branch = branch

--- a/lib/siriproxy/connection/iphone.rb
+++ b/lib/siriproxy/connection/iphone.rb
@@ -31,7 +31,7 @@ class SiriProxy::Connection::Iphone < SiriProxy::Connection
     
     addresses.map do |address|
       address.address.unpack('C*').join('.')
-    end.sample(1).first
+    end.sample
   end
 
   def ssl_handshake_completed

--- a/lib/siriproxy/connection/iphone.rb
+++ b/lib/siriproxy/connection/iphone.rb
@@ -4,10 +4,11 @@ require 'resolv'
   # This is the connection to the iPhone
 #####
 class SiriProxy::Connection::Iphone < SiriProxy::Connection
-  def initialize
+  def initialize upstream_dns
     puts "Create server for iPhone connection"
-    super
+    super()
     self.name = "iPhone"
+    @upstream_dns = upstream_dns
   end
 
   def post_init
@@ -20,8 +21,9 @@ class SiriProxy::Connection::Iphone < SiriProxy::Connection
   # Resolves guzzoni.apple.com using the Google DNS servers.  This allows the
   # machine running siriproxy to use the DNS server returning fake records for
   # guzzoni.apple.com.
+
   def resolve_guzzoni
-    addresses = Resolv::DNS.open(nameserver: %w[8.8.8.8 8.8.4.4]) do |dns|
+    addresses = Resolv::DNS.open(nameserver: @upstream_dns) do |dns|
       res = dns.getresources('guzzoni.apple.com', Resolv::DNS::Resource::IN::A)
     
       res.map { |r| r.address }
@@ -29,7 +31,7 @@ class SiriProxy::Connection::Iphone < SiriProxy::Connection
     
     addresses.map do |address|
       address.address.unpack('C*').join('.')
-    end.sample(1)
+    end.sample(1).first
   end
 
   def ssl_handshake_completed


### PR DESCRIPTION
With this pull request the siriproxy server uses ruby's Resolv library to query Google Public DNS for the address of guzzoni.apple.com.  This allows the server host to use the DNS server that is redirecting to siriproxy.

If Google Public DNS is inaccessible or otherwise inappropriate the user may override with `--upstream-dns`
