### PR TITLE
Fix for CFPropertyList error, closes #389 also stuck command fix for #143

### DIFF
--- a/lib/siriproxy/connection.rb
+++ b/lib/siriproxy/connection.rb
@@ -169,6 +169,11 @@ class SiriProxy::Connection < EventMachine::Connection
   end
   
   def prep_received_object(object)
+      
+    if object["class"] == "FinishSpeech" or object["class"] == "SpeechRecognized"
+          @block_rest_of_session = false
+    end
+      
     if object["refId"] == self.last_ref_id && @block_rest_of_session
       puts "[Info - Dropping Object from Guzzoni] #{object["class"]}" if $LOG_LEVEL > 1
       pp object if $LOG_LEVEL > 3

--- a/siriproxy.gemspec
+++ b/siriproxy.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.2")
 
-  s.add_runtime_dependency "CFPropertyList"
+  s.add_runtime_dependency('CFPropertyList', '2.1.2')
   s.add_runtime_dependency "eventmachine"
   s.add_runtime_dependency "uuidtools"
   s.add_development_dependency "rake"


### PR DESCRIPTION
V 2.2.0 of CFPropertyList would crash Siriproxy after the mic button was pressed, this forces it to use version 2.1.2.

Fixes InvalidByteSequenceError and closes https://github.com/plamoni/SiriProxy/issues/389

Second part fixed #143 with fix found by @Raggyx
