### PR TITLE
Add support for specifying IP Address to listen on

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,3 +1,4 @@
+listen: 0.0.0.0
 port: 443
 log_level: 1
 plugins:

--- a/lib/siriproxy.rb
+++ b/lib/siriproxy.rb
@@ -15,8 +15,8 @@ class SiriProxy
     $LOG_LEVEL = $APP_CONFIG.log_level.to_i
     EventMachine.run do
       begin
-        puts "Starting SiriProxy on port #{$APP_CONFIG.port}.."
-        EventMachine::start_server('0.0.0.0', $APP_CONFIG.port, SiriProxy::Connection::Iphone) { |conn|
+        puts "Starting SiriProxy on #{$APP_CONFIG.listen}:#{$APP_CONFIG.port}.."
+        EventMachine::start_server($APP_CONFIG.listen, $APP_CONFIG.port, SiriProxy::Connection::Iphone) { |conn|
           $stderr.puts "start conn #{conn.inspect}"
           conn.plugin_manager = SiriProxy::PluginManager.new()
           conn.plugin_manager.iphone_conn = conn

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -143,6 +143,9 @@ Options:
     $APP_CONFIG = OpenStruct.new(YAML.load_file(File.expand_path('~/.siriproxy/config.yml')))
     @branch = nil
     @option_parser = OptionParser.new do |opts|
+      opts.on('-l', '--listen ADDRESS',     '[server]   address to listen on (central or node)') do |listen|
+        $APP_CONFIG.listen = listen
+      end
       opts.on('-p', '--port PORT',     '[server]   port number for server (central or node)') do |port_num|
         $APP_CONFIG.port = port_num
       end

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -143,7 +143,7 @@ Options:
     $APP_CONFIG = OpenStruct.new(YAML.load_file(File.expand_path('~/.siriproxy/config.yml')))
     @branch = nil
     @option_parser = OptionParser.new do |opts|
-      opts.on('-l', '--listen ADDRESS',     '[server]   address to listen on (central or node)') do |listen|
+      opts.on('-L', '--listen ADDRESS',     '[server]   address to listen on (central or node)') do |listen|
         $APP_CONFIG.listen = listen
       end
       opts.on('-p', '--port PORT',     '[server]   port number for server (central or node)') do |port_num|


### PR DESCRIPTION
This patch adds a listen parameter to the config.yml and to the config options.
Useful if you only want to listen on one IP address.
