### PR TITLE
Don't remove non-space characters even if 'removeSpaceBefore' property is true

### DIFF
--- a/lib/siriproxy/interpret_siri.rb
+++ b/lib/siriproxy/interpret_siri.rb
@@ -38,7 +38,7 @@ class SiriProxy::Interpret
         phraseObj["properties"]["interpretations"].first["properties"]["tokens"].map { |token|
           tokenProps = token["properties"]
           
-          phrase = phrase[0..-2] if tokenProps["removeSpaceBefore"]
+          phrase = phrase[0..-2] if tokenProps["removeSpaceBefore"] and phrase[-1] == " "
           phrase << tokenProps["text"]
           phrase << " " if !tokenProps["removeSpaceAfter"]
         }


### PR DESCRIPTION
In non-space delimited languages (such as Japanese), Guzzoni may return SpeechRecognized
object with removeSpaceBefore property = true even when the previous phrase does not end
with space character. This patch checks the previous phrase really ends with space before
removing the last character.
