### PR TITLE
fix dns.rb

### DIFF
--- a/lib/siriproxy/dns.rb
+++ b/lib/siriproxy/dns.rb
@@ -53,7 +53,7 @@ class SiriProxy::Dns
       RubyDNS::run_server(:listen => @interfaces) do
         @logger.level = log_level
 
-        match(/guzzoni.apple.com/, Resolv::DNS::Resource::IN::A) do |_host, transaction|
+        match(/guzzoni.apple.com/, Resolv::DNS::Resource::IN::A) do |transaction|
           transaction.respond!(server_ip)
         end
 

--- a/siriproxy.gemspec
+++ b/siriproxy.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "cora", "=0.0.4"
   s.add_runtime_dependency "bundler"
   s.add_runtime_dependency "rake"
-  s.add_runtime_dependency "rubydns", ">= 0.6.0"
+  s.add_runtime_dependency "rubydns", "~> 0.6.0"
 end

--- a/siriproxy.gemspec
+++ b/siriproxy.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "cora", "=0.0.4"
   s.add_runtime_dependency "bundler"
   s.add_runtime_dependency "rake"
-  s.add_runtime_dependency "rubydns"
+  s.add_runtime_dependency "rubydns", ">= 0.6.0"
 end


### PR DESCRIPTION
Removed _host variable from regex block. Probably hacky but it works for now. Thanks to HaroldW.
