### PR TITLE
Fixed trailing space after recognized text

### DIFF
--- a/lib/siriproxy/interpret_siri.rb
+++ b/lib/siriproxy/interpret_siri.rb
@@ -44,7 +44,7 @@ class SiriProxy::Interpret
         }
       }
       
-      phrase
+      phrase.strip
     end
   end
 end


### PR DESCRIPTION
Fixed trailing space after recognized text -- this unnecessarily complicates listen_for implementations.
