### PR TITLE
Implement a run() method for external usage

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm 1.9.3@SiriProxy --create

--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -47,6 +47,34 @@ Options:
     end
   end
 
+  def run(input)
+    load_code
+    init_plugins
+    # this is ugly, but works for now
+    SiriProxy::PluginManager.class_eval do
+      def respond(text, options={})
+        @response = text
+      end
+      def process(text)
+        super(text)
+      end
+      def send_request_complete_to_iphone
+      end
+      def no_matches
+        @response = "No plugin responded"
+      end
+    end
+    SiriProxy::Plugin.class_eval do
+      def last_ref_id
+        0
+      end
+    end
+
+    cora = SiriProxy::PluginManager.new
+    cora.process(input)
+    return cora.response
+  end
+
   def run_console
     load_code
     init_plugins

--- a/lib/siriproxy/plugin_manager.rb
+++ b/lib/siriproxy/plugin_manager.rb
@@ -2,7 +2,7 @@ require 'cora'
 require 'pp'
 
 class SiriProxy::PluginManager < Cora
-  attr_accessor :plugins, :iphone_conn, :guzzoni_conn
+  attr_accessor :plugins, :iphone_conn, :guzzoni_conn, :response
 
   def initialize()
     load_plugins()

--- a/lib/siriproxy/version.rb
+++ b/lib/siriproxy/version.rb
@@ -1,3 +1,3 @@
 class SiriProxy
-  VERSION = "0.5.4"
+  VERSION = "0.5.5"
 end


### PR DESCRIPTION
I wanted to be able to use my SiriProxy plugins outside of the normal SiriProxy context, pull request adds a run() method for that purpose. Accepts a string input, returns SiriProxy's response from any plugins. I've tested it with an IRC plugin.

```
require 'siriproxy/command_line'

siri = SiriProxy::CommandLine.new
puts siri.run("test siri proxy")
```
